### PR TITLE
add support for defining cmd on a per-project level

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ To install via Package Control, do the following:
 ## Settings
 For general information on how SublimeLinter works with settings, please see [Settings](http://sublimelinter.readthedocs.org/en/latest/settings.html). For information on generic linter settings, please see [Linter Settings](http://sublimelinter.readthedocs.org/en/latest/linter_settings.html).
 
+### Project Specific Executable
+It is possible to specify the `phpcs` executable that should be used to lint your code on a per-project level.
+
+**Example:**
+```json
+{
+    "SublimeLinter": {
+        "linters": {
+            "phpmd": {
+                "cmd": "${project}/vendor/bin/phpmd"
+            }
+        }
+    }
+}
+```
+
 ## Contributing
 If you would like to contribute enhancements or fixes, please do the following:
 

--- a/linter.py
+++ b/linter.py
@@ -14,11 +14,11 @@ from SublimeLinter.lint import highlight, Linter
 
 
 class Phpmd(Linter):
-
     """Provides an interface to phpmd."""
 
     syntax = ('php', 'html', 'html 5')
     cmd = 'phpmd @ text'
+    executable = 'phpmd'
     regex = (
         r'(?P<filename>.+):(?P<line>\d+)'
         r'\s*(?P<message>.+)$'
@@ -30,3 +30,18 @@ class Phpmd(Linter):
     }
     inline_overrides = 'rulesets'
     comment_re = r'\s*<!--'
+
+    def cmd(self):
+        """Create the cmd."""
+        settings = Linter.get_view_settings(self)
+
+        # attempt to get the command from settings if it is present
+        if 'cmd' in settings:
+            command = [settings.get('cmd')]
+        else:
+            command = [self.executable_path]
+
+        command.append('@')
+        command.append('text')
+
+        return command

--- a/messages.json
+++ b/messages.json
@@ -1,3 +1,4 @@
 {
-    "install": "messages/install.txt"
+    "install": "messages/install.txt",
+    "1.1.0": "messages/1.1.0.txt"
 }

--- a/messages/1.1.0.txt
+++ b/messages/1.1.0.txt
@@ -1,0 +1,15 @@
+SublimeLinter-phpmd 1.1.0
+---------------------------
+
+This version adds support for declaring per-project linter executable files.
+
+Example (*.sublime-project):
+{
+    "SublimeLinter": {
+        "linters": {
+            "phpmd": {
+                "cmd": "${project}/vendor/bin/phpmd"
+            }
+        }
+    }
+}


### PR DESCRIPTION
* implements a custom `cmd()` method to check for the existence of an `cmd` setting
* updated README documentation to show example of new functionality

closes #10