### PR TITLE
Do not capture 'filename'

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -4,8 +4,10 @@ from SublimeLinter.lint import Linter, WARNING
 class Phpmd(Linter):
     cmd = ('phpmd', '${temp_file}', 'text')
     regex = (
-        r'(?P<filename>.+):(?P<line>\d+)'
-        r'\s*(?P<message>.+)$'
+        # For now, do *NOT* capture 'filename' since phpmd reports 'real'
+        # paths, and Sublime and SL cannot map such paths to the original
+        # `view.file_name()`.
+        r'(.+):(?P<line>\d+)\s*(?P<message>.+)$'
     )
     on_stderr = None  # handle stderr via regex
     default_type = WARNING


### PR DESCRIPTION
phpmd resolves all paths to 'real' paths and uses such 'real' paths in the reports. 

Since we cannot map such a 'real' path back to a 'user' path, we MUST not capture these filename. (We basically need a 1-1 mapping from a view filename to a reported filename.) 

Fixes #21
Fixes https://github.com/SublimeLinter/SublimeLinter/issues/1589