### PR TITLE
add local composer installation phpmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,11 @@ Make sure [Package Control](https://packagecontrol.io) is installed.
 
 ### Install `phpmd`
 
-#### local install (within a project) with [Composer](https://getcomposer.org/)
+Choose one of the installation methods below.
+
+A local install allows you to fine-tune `phpmd` on a per-project basis. A global install is available system-wide.
+
+#### local install (available on a per-project basis) with [Composer](https://getcomposer.org/)
 
 ```bash
 composer require phpmd/phpmd

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ Choose one of the installation methods below.
 
 A local install allows you to fine-tune `phpmd` on a per-project basis. A global install is available system-wide.
 
-#### local install (available on a per-project basis) with [Composer](https://getcomposer.org/)
+#### local install with [Composer](https://getcomposer.org/)
 
+On a command line inside your project:
 ```bash
 composer require phpmd/phpmd
 ```

--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ Make sure [Package Control](https://packagecontrol.io) is installed.
 1. Open the command palette (Ctrl + Shift + P)
 2. Type **Package Control: Install Package** and select it.
 3. Type **SublimeLinter** and select it.
-4. Repeat steps 1-3 using **SublimeLinter-phpmd** in step 3.
+4. Repeat steps 1-3 typing **SublimeLinter-phpmd** in step 3.
 
 ### Install `phpmd`
 
-#### phpmd local install (within a project) with [Composer](https://getcomposer.org/)
+#### local install (within a project) with [Composer](https://getcomposer.org/)
 
 ```bash
 composer require phpmd/phpmd
@@ -37,7 +37,7 @@ Set the `phpmd` executable by adding/editing:
   }
 ```
 
-#### phpmd global install with [Composer](https://getcomposer.org/)
+#### global install with [Composer](https://getcomposer.org/)
 
 ```bash
 composer global require phpmd/phpmd
@@ -49,7 +49,7 @@ Make sure the composer global bin directory is available in $PATH:
 export PATH=~/.composer/vendor/bin:$PATH
 ```
 
-#### phpmd global install with [PEAR](https://pear.php.net)
+#### global install with [PEAR](https://pear.php.net)
 
 ```bash
 pear channel-discover pear.phpmd.org

--- a/README.md
+++ b/README.md
@@ -9,24 +9,24 @@ It will be used with files that have the "PHP", "HTML" and "HTML5" syntax.
 
 ## Installation
 
-First, install phpmd with Composer or PEAR.
-Then install SublimeLinter and SublimeLinter-phpmd with Package Control.
+### Install `SublimeLinter` and `SublimeLinter-phpmd`
 
-### 1. Installing phpmd
+Make sure [Package Control](https://packagecontrol.io) is installed.
 
-Make sure [PHP](https://www.php.net) is installed.
+Open the command palette (Ctrl + Shift + P) and choose **Package Control: Install Package**. Type **SublimeLinter** and select it. Repeat this for **SublimeLinter-phpmd**.
 
-#### 1.1 Installing phpmd with [Composer](https://getcomposer.org/):
+### Install phpmd
 
-##### 1.1.1 Local install (within a project)
+#### phpmd local install (within a project) with [Composer](https://getcomposer.org/)
 
-1. Install `phpmd` from a command line:
-```
+```bash
 composer require phpmd/phpmd
 ```
-2. Open **Preferences -> Package Settings -> SublimeLinter -> Settings**
-3. Set the `phpmd` executable by adding/editing:
-```
+
+Inside Sublime, go to **Preferences -> Package Settings -> SublimeLinter -> Settings**.
+
+Set the `phpmd` executable by adding/editing:
+```json
   "linters": {
     "phpmd": {
       "executable": "${folder}/vendor/bin/phpmd"
@@ -34,37 +34,25 @@ composer require phpmd/phpmd
   }
 ```
 
-##### 1.1.2 Global install
+##### phpmd global install with [Composer](https://getcomposer.org/)
 
-1. Install `phpmd` from a command line:
-```
+```bash
 composer global require phpmd/phpmd
 ```
-2. Make sure the composer global bin directory is available in $PATH
-```
+
+Make sure the composer global bin directory is available in $PATH:
+
+```bash
 export PATH=~/.composer/vendor/bin:$PATH
 ```
 
-#### 1.2 Installing phpmd with [PEAR](https://pear.php.net)
+#### phpmd global install with [PEAR](https://pear.php.net)
 
-Install `phpmd` from a command line:
-```
+```bash
 pear channel-discover pear.phpmd.org
 pear channel-discover pear.pdepend.org
 pear install --alldeps phpmd/PHP_PMD
 ```
-
-### 2. Installing SublimeLinter
-
-Make sure [Package Control](https://packagecontrol.io) is installed.
-
-1. Open the command palette (Ctrl + Shift + P) and choose **Package Control: Install Package**.
-2. Type **SublimeLinter** and select it.
-
-### 3. Installing SublimeLinter-phpmd
-
-1. Open the command palette (Ctrl + Shift + P) and choose **Package Control: Install Package**.
-2. Type **SublimeLinter-phpmd** and select it.
 
 ## Settings
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ It will be used with files that have the "PHP", "HTML" and "HTML5" syntax.
 
 Make sure [Package Control](https://packagecontrol.io) is installed.
 
-Open the command palette (Ctrl + Shift + P) and choose **Package Control: Install Package**. Type **SublimeLinter** and select it. Repeat this for **SublimeLinter-phpmd**.
+1. Open the command palette (Ctrl + Shift + P)
+2. Type **Package Control: Install Package** and select it.
+3. Type **SublimeLinter** and select it.
+4. Repeat steps 1-3 using **SublimeLinter-phpmd** in step 3.
 
-### Install phpmd
+### Install `phpmd`
 
 #### phpmd local install (within a project) with [Composer](https://getcomposer.org/)
 
@@ -34,7 +37,7 @@ Set the `phpmd` executable by adding/editing:
   }
 ```
 
-##### phpmd global install with [Composer](https://getcomposer.org/)
+#### phpmd global install with [Composer](https://getcomposer.org/)
 
 ```bash
 composer global require phpmd/phpmd

--- a/README.md
+++ b/README.md
@@ -9,36 +9,62 @@ It will be used with files that have the "PHP", "HTML" and "HTML5" syntax.
 
 ## Installation
 
-SublimeLinter must be installed in order to use this plugin. 
+First, install phpmd with Composer or PEAR.
+Then install SublimeLinter and SublimeLinter-phpmd with Package Control.
 
-Please use [Package Control](https://packagecontrol.io) to install the linter plugin.
+### 1. Installing phpmd
 
-Before installing this plugin, ensure that `phpmd` is installed on your system.
-To install `phpmd`, do the following:
+Make sure [PHP](https://www.php.net) is installed.
 
-1. Install [php](http://php.net).
+#### 1.1 Installing phpmd with [Composer](https://getcomposer.org/):
 
-2. Install [pear](http://pear.php.net).
+##### 1.1.1 Local install (within a project)
 
-3. Install `phpmd` by typing the following in a terminal:
-   ```
-   pear channel-discover pear.phpmd.org
-   pear channel-discover pear.pdepend.org
-   pear install --alldeps phpmd/PHP_PMD
-   ```
+1. Install `phpmd` from a command line:
+```
+composer require phpmd/phpmd
+```
+2. Open **Preferences -> Package Settings -> SublimeLinter -> Settings**
+3. Set the `phpmd` executable by adding/editing:
+```
+  "linters": {
+    "phpmd": {
+      "executable": "${folder}/vendor/bin/phpmd"
+    }
+  }
+```
 
-### Alternative installation using [composer](https://getcomposer.org/):
+##### 1.1.2 Global install
 
-1. Install [composer](https://getcomposer.org/).
-2. Install `phpmd` using below command:
+1. Install `phpmd` from a command line:
 ```
 composer global require phpmd/phpmd
 ```
-3. Make sure composer global bin directory is available in $PATH
+2. Make sure the composer global bin directory is available in $PATH
 ```
 export PATH=~/.composer/vendor/bin:$PATH
 ```
 
+#### 1.2 Installing phpmd with [PEAR](https://pear.php.net)
+
+Install `phpmd` from a command line:
+```
+pear channel-discover pear.phpmd.org
+pear channel-discover pear.pdepend.org
+pear install --alldeps phpmd/PHP_PMD
+```
+
+### 2. Installing SublimeLinter
+
+Make sure [Package Control](https://packagecontrol.io) is installed.
+
+1. Open the command palette (Ctrl + Shift + P) and choose **Package Control: Install Package**.
+2. Type **SublimeLinter** and select it.
+
+### 3. Installing SublimeLinter-phpmd
+
+1. Open the command palette (Ctrl + Shift + P) and choose **Package Control: Install Package**.
+2. Type **SublimeLinter-phpmd** and select it.
 
 ## Settings
 


### PR DESCRIPTION
I've added installation guidelines for a per-project phpmd installation (as this offers finer control over its version) and restructured the installation steps as a whole.