### PR TITLE
document rulesets setting, support baseline files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Therefore, set the "real_file_mode" setting to true.
 ```json
 "linters": {
   "phpmd": {
-    "real_file_mode": "codesize,unusedcode,naming"
+    "real_file_mode": true
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pear install --alldeps phpmd/PHP_PMD
 - SublimeLinter settings: http://sublimelinter.com/en/latest/settings.html
 - Linter settings: http://sublimelinter.com/en/latest/linter_settings.html
 
-### rulesets
+### Rulesets
 
 You can configure rules via the `rulesets` setting. This can be a list of rules, or a path to a custom ruleset file.
 
@@ -81,6 +81,18 @@ You can configure rules via the `rulesets` setting. This can be a list of rules,
   "linters": {
     "phpmd": {
       "rulesets": "${folder}/phpmd.xml"
+    }
+  }
+```
+
+### Baseline
+
+If you want to use a baseline file, the linter needs to run on the actual files instead of the temporary files we need for real-time "background" linting. Therefore, set the [lint_mode](http://www.sublimelinter.com/en/stable/linter_settings.html#lint-mode) for phphmd to "load_save", "save" or "manual":
+
+```json
+  "linters": {
+    "phpmd": {
+      "lint_mode": "load_save"
     }
   }
 ```

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 SublimeLinter-phpmd
 =========================
 
-[![Build Status](https://travis-ci.org/SublimeLinter/SublimeLinter-phpmd.svg?branch=master)](https://travis-ci.org/SublimeLinter/SublimeLinter-phpmd)
-
 This linter plugin for [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter) provides an interface to [phpmd](http://phpmd.org/documentation/index.html).
 It will be used with files that have the "PHP", "HTML" and "HTML5" syntax.
 
@@ -67,4 +65,22 @@ pear install --alldeps phpmd/PHP_PMD
 - SublimeLinter settings: http://sublimelinter.com/en/latest/settings.html
 - Linter settings: http://sublimelinter.com/en/latest/linter_settings.html
 
+### rulesets
 
+You can configure rules via the `rulesets` setting. This can be a list of rules, or a path to a custom ruleset file.
+
+```json
+  "linters": {
+    "phpmd": {
+      "rulesets": "codesize,unusedcode,naming"
+    }
+  }
+```
+
+```json
+  "linters": {
+    "phpmd": {
+      "rulesets": "${folder}/phpmd.xml"
+    }
+  }
+```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,19 @@ pear install --alldeps phpmd/PHP_PMD
 - SublimeLinter settings: http://sublimelinter.com/en/latest/settings.html
 - Linter settings: http://sublimelinter.com/en/latest/linter_settings.html
 
+### Additional settings
+
+If you want to use a baseline file, the linter needs to run on the actual files instead of the temporary files we need for real-time "background" linting. 
+Therefore, set the "real_file_mode" setting to true.
+
+```json
+"linters": {
+  "phpmd": {
+    "real_file_mode": "codesize,unusedcode,naming"
+  }
+}
+```
+
 ### Rulesets
 
 You can configure rules via the `rulesets` setting. This can be a list of rules, or a path to a custom ruleset file.
@@ -81,18 +94,6 @@ You can configure rules via the `rulesets` setting. This can be a list of rules,
   "linters": {
     "phpmd": {
       "rulesets": "${folder}/phpmd.xml"
-    }
-  }
-```
-
-### Baseline
-
-If you want to use a baseline file, the linter needs to run on the actual files instead of the temporary files we need for real-time "background" linting. Therefore, set the [lint_mode](http://www.sublimelinter.com/en/stable/linter_settings.html#lint-mode) for phphmd to "load_save", "save" or "manual":
-
-```json
-  "linters": {
-    "phpmd": {
-      "lint_mode": "load_save"
     }
   }
 ```

--- a/linter.py
+++ b/linter.py
@@ -2,14 +2,20 @@ from SublimeLinter.lint import Linter, WARNING
 
 
 class Phpmd(Linter):
-    cmd = ('phpmd', '${file}', 'text')
     regex = (
         r'(.+):(?P<line>\d+)\s*(?P<message>.+)$'
     )
     on_stderr = None  # handle stderr via regex
     default_type = WARNING
-    tempfile_suffix = '-'
+    tempfile_suffix = 'php'
     defaults = {
         'selector': 'embedding.php, source.php',
         '@rulesets:,': 'cleancode,codesize,controversial,design,naming,unusedcode'
     }
+
+    def cmd(self):
+        if self.settings['lint_mode'] != 'background':
+            self.tempfile_suffix = '-'
+            return ('phpmd', '${file}', 'text')
+
+        return ('phpmd', '${temp_file}', 'text')

--- a/linter.py
+++ b/linter.py
@@ -16,6 +16,6 @@ class Phpmd(Linter):
     def cmd(self):
         if self.settings['lint_mode'] != 'background':
             self.tempfile_suffix = '-'
-            return ('phpmd', '${file}', 'text')
+            return ('phpmd', '${file_on_disk}', 'text')
 
         return ('phpmd', '${temp_file}', 'text')

--- a/linter.py
+++ b/linter.py
@@ -2,16 +2,13 @@ from SublimeLinter.lint import Linter, WARNING
 
 
 class Phpmd(Linter):
-    cmd = ('phpmd', '${temp_file}', 'text')
+    cmd = ('phpmd', '${file}', 'text')
     regex = (
-        # For now, do *NOT* capture 'filename' since phpmd reports 'real'
-        # paths, and Sublime and SL cannot map such paths to the original
-        # `view.file_name()`.
         r'(.+):(?P<line>\d+)\s*(?P<message>.+)$'
     )
     on_stderr = None  # handle stderr via regex
     default_type = WARNING
-    tempfile_suffix = 'php'
+    tempfile_suffix = '-'
     defaults = {
         'selector': 'embedding.php, source.php',
         '@rulesets:,': 'cleancode,codesize,controversial,design,naming,unusedcode'

--- a/linter.py
+++ b/linter.py
@@ -9,6 +9,7 @@ class Phpmd(Linter):
     default_type = WARNING
     tempfile_suffix = 'php'
     defaults = {
+        'real_file_mode': False,
         'selector': 'embedding.php, source.php',
         '@rulesets:,': 'cleancode,codesize,controversial,design,naming,unusedcode'
     }
@@ -22,7 +23,7 @@ class Phpmd(Linter):
         ):
             return False
 
-        return super().should_lint(cls, view, settings, reason)
+        return super().should_lint(view, settings, reason)
 
     def cmd(self):
         target = '$file_on_disk' if self.settings['real_file_mode'] else '$temp_file'

--- a/linter.py
+++ b/linter.py
@@ -1,4 +1,4 @@
-from SublimeLinter.lint import Linter, WARNING
+from SublimeLinter.lint import Linter, TransientError, WARNING
 
 
 class Phpmd(Linter):
@@ -15,6 +15,12 @@ class Phpmd(Linter):
 
     def cmd(self):
         if self.settings['lint_mode'] != 'background':
+            # lint real files only, but only if the buffer is not dirty
+            window = self.view.window()
+            if window and self.view.is_dirty() or not self.view.file_name():
+                window.status_message("phpmd: please save to lint this file")
+                raise TransientError("Abort.  Buffer is dirty.")
+
             self.tempfile_suffix = '-'
             return ('phpmd', '${file_on_disk}', 'text')
 


### PR DESCRIPTION
- document rulesets setting
  the info is not available in the README,
  probably since we temporarily remove it years ago

Currently the linter does not support baseline files because we're using temp files. I want to look into that too.